### PR TITLE
hunter_config(xgboost VERSION 0.40-p4 CMAKE_ARGS XGBOOST_DO_LEAN=ON X…

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -47,7 +47,7 @@ hunter_config(OpenCV VERSION 3.0.0-p7 CMAKE_ARGS "${OPENCV_CMAKE_ARGS}")
 ### Boost
 hunter_config(Boost VERSION 1.58.0-p1 CMAKE_ARGS IOSTREAMS_NO_BZIP2=1 )
 
-hunter_config(xgboost VERSION 0.40-p4)
+hunter_config(xgboost VERSION 0.40-p4 CMAKE_ARGS XGBOOST_DO_LEAN=ON XGBOOST_USE_HALF=ON XGBOOST_USE_BOOST=ON)
 hunter_config(PNG VERSION 1.6.26-p1)
 hunter_config(TIFF VERSION 4.0.2-p3)
 hunter_config(cereal VERSION 1.1.2-p5)


### PR DESCRIPTION
…GBOOST_USE_HALF=ON XGBOOST_USE_BOOST=ON)

use "lean" xgboost (predict only) by default

Note: For local (on host) training this will need to be disabled.