### PR TITLE
Revert "add boost regex (used for ios ctes/gtest)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(is_empty)
 endif()
 
 if(LEVEL EQUAL 1)
-  hunter_add_package(Boost COMPONENTS filesystem system serialization iostreams regex)
+  hunter_add_package(Boost COMPONENTS filesystem system serialization iostreams)
   hunter_add_package(Eigen)
   hunter_add_package(PNG)
   hunter_add_package(TIFF)


### PR DESCRIPTION
This reverts commit ac2f328ca3744e4ed53feeb425004015b913a0ac.