### PR TITLE
use CMAKE_XCODE_ATTRIBUTE_WARNING for `-Wno-narrowing`

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -42,7 +42,9 @@ list(APPEND OPENCV_CMAKE_ARGS
   BUILD_EIGEN=OFF  ### for convenient linking
   )
 
-if(NOT MSVC)
+if(XCODE)
+  list(APPEND OPENCV_CMAKE_ARGS CMAKE_XCODE_ATTRIBUTE_WARNING_CFLAGS=-Wno-narrowing)
+elseif(NOT MSVC)
   list(APPEND OPENCV_CMAKE_ARGS CMAKE_CXX_FLAGS=-Wno-narrowing)
 endif()
 


### PR DESCRIPTION
fix opencv + xcode warnings 