### PR TITLE
Leaner Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,7 @@ matrix:
     - stage: Upload level 1
       os: osx
       osx_image: xcode8.1
-      env: TOOLCHAIN=ios-nocodesign-10-1-dep-9-0-device-libcxx-hid-sections-lto CONFIG=MinSizeRel LEVEL=1
-    - stage: Upload level 1
-      os: osx
-      osx_image: xcode8.1
-      env: TOOLCHAIN=osx-10-12-sanitize-address-hid-sections CONFIG=Debug LEVEL=1
+      env: TOOLCHAIN=ios-nocodesign-10-1-arm64-dep-9-0-device-libcxx-hid-sections-lto CONFIG=MinSizeRel LEVEL=1
     - stage: Upload level 1
       os: osx
       osx_image: xcode8.1
@@ -80,11 +76,7 @@ matrix:
     - stage: Upload level 2
       os: osx
       osx_image: xcode8.1
-      env: TOOLCHAIN=ios-nocodesign-10-1-dep-9-0-device-libcxx-hid-sections-lto CONFIG=MinSizeRel LEVEL=2
-    - stage: Upload level 2
-      os: osx
-      osx_image: xcode8.1
-      env: TOOLCHAIN=osx-10-12-sanitize-address-hid-sections CONFIG=Debug LEVEL=2
+      env: TOOLCHAIN=ios-nocodesign-10-1-arm64-dep-9-0-device-libcxx-hid-sections-lto CONFIG=MinSizeRel LEVEL=2
     - stage: Upload level 2
       os: osx
       osx_image: xcode8.1
@@ -109,11 +101,7 @@ matrix:
     - stage: Upload level 3
       os: osx
       osx_image: xcode8.1
-      env: TOOLCHAIN=ios-nocodesign-10-1-dep-9-0-device-libcxx-hid-sections-lto CONFIG=MinSizeRel LEVEL=3
-    - stage: Upload level 3
-      os: osx
-      osx_image: xcode8.1
-      env: TOOLCHAIN=osx-10-12-sanitize-address-hid-sections CONFIG=Debug LEVEL=3
+      env: TOOLCHAIN=ios-nocodesign-10-1-arm64-dep-9-0-device-libcxx-hid-sections-lto CONFIG=MinSizeRel LEVEL=3
     - stage: Upload level 3
       os: osx
       osx_image: xcode8.1


### PR DESCRIPTION
* drop Debug version of xcode ASAN toolchain (osx-10-12-sanitize-address-hid-sections) — this reduces the builds to 5 jobs which matches travis open source allowance (Release ASAN is still active)
* reduce ios framework from full armv7+armv7s+arm64 iOS universal libto to single arm64 build: ios-nocodesign-10-1-arm64-dep-9-0-device-libcxx-hid-sections-lto