### PR TITLE
remove BUILD_opencv_world option

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -37,11 +37,9 @@ option(DRISHTI_BUILD_OGLES_GPGPU "Build with OGLES_GPGPU" ON)
 option(DRISHTI_BUILD_ACF "Drishti ACF lib" ON)
 option(DRISHTI_OPENGL_ES3 "Support OpenGL ES 3.0 (default 2.0)" OFF)
 option(DRISHTI_BUILD_MIN_SIZE "Build minimum size lib (exclude training)" ON)
-option(DRISHTI_BUILD_OPENCV_WORLD "Build OpenCV world (monolithic lib)" ON)
 option(DRISHTI_SERIALIZE_WITH_CVMATIO "Perform serialization with cvmatio" OFF)
 
 list(APPEND OPENCV_CMAKE_ARGS
-  BUILD_opencv_world=${DRISHTI_BUILD_OPENCV_WORLD}
   BUILD_opencv_ts=OFF
   BUILD_opencv_python2=OFF
   BUILD_opencv_shape=OFF


### PR DESCRIPTION
Some opencv_world build issues introduced w/ opencv 3.4.1-p1:

https://travis-ci.org/elucideye/drishti/jobs/364771145

```
CMake Error at modules/world/CMakeLists.txt:80 (add_custom_command):
  Error evaluating generator expression:
    $<TARGET_LINKER_FILE:/Users/travis/.hunter/_Base/3fda02c/7e4ce58/2854473/Install/lib/libjpeg.a>
  Expression syntax not recognized.

CMake Error at modules/world/CMakeLists.txt:80 (add_custom_command):
  Error evaluating generator expression:
    $<TARGET_LINKER_FILE:/Users/travis/.hunter/_Base/3fda02c/7e4ce58/2854473/Install/lib/libjpeg.a>
  Expression syntax not recognized.

CMake Error at modules/world/CMakeLists.txt:67 (add_dependencies):
  The dependency target
  "/Users/travis/.hunter/_Base/3fda02c/7e4ce58/2854473/Install/lib/libjpeg.a"
  of target "opencv_world" does not exist.
Call Stack (most recent call first):
  modules/world/CMakeLists.txt:77 (ios_include_3party_libs)

```